### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-test-coverage:
     name: Build, Test & Coverage


### PR DESCRIPTION
Potential fix for [https://github.com/Franchef/Semantic.NET/security/code-scanning/1](https://github.com/Franchef/Semantic.NET/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` so the workflow does not rely on inherited defaults.  
Best fix without changing functionality: define permissions at the workflow root (applies to all jobs unless overridden), using the minimal required scope.

For this workflow, a safe minimal baseline is:

- `contents: read` (needed by `actions/checkout` to fetch repository contents)

No additional write scopes are required by the shown steps. This keeps current behavior while reducing token privileges.

Modify `.github/workflows/ci.yml` right after the `on:` trigger block and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
