### PR TITLE
feat: semantic state machines (Moore/Mealy), robustness tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ if (pattern.HasMatch())
 
 See the unit tests in `SemanticTests/Sequences/PatternMatchesTests.cs` for more usage details.
 
+## Example: Sliding Window Utility
+
+```csharp
+var window = SlidingWindowBuilder.Create<int>(3);
+
+window.Add(10);
+window.Add(20);
+window.Add(30);
+// [10, 20, 30]
+
+window.Add(40);
+// [20, 30, 40]
+
+var items = window.GetItems();
+```
+
 ## Example: Semantic State Machine Builders
 
 State machines can also be configured with a fluent API that guides transition definitions:
@@ -47,6 +63,9 @@ var machine = Moore<MyState>.Builder(MyState.Idle)
     .From(MyState.Idle).On("start").GoTo(MyState.Running)
     .From(MyState.Running).On("stop").GoTo(MyState.Stopped)
     .Build();
+
+machine.ProcessInput("start");
+// machine.CurrentState == MyState.Running
 ```
 
 For Mealy machines, each transition concludes with an explicit output:
@@ -56,16 +75,31 @@ var mealy = Mealy<MyState>.Builder(MyState.Idle)
     .From(MyState.Idle).On("start").GoTo(MyState.Running).Emits("started")
     .From(MyState.Running).On("stop").GoTo(MyState.Idle).Emits("stopped")
     .Build();
+
+var output = mealy.ProcessInput("start");
+// output == "started"
 ```
 
 Typed variants are available when you want compile-time safety on inputs and outputs:
 
 ```csharp
+var typedMoore = Moore<MyState, string>.Builder(MyState.Idle)
+    .WithState(MyState.Idle, _ => StateMachine<MyState>.NoTransition())
+    .WithState(MyState.Running, _ => StateMachine<MyState>.NoTransition())
+    .WithState(MyState.Stopped, _ => StateMachine<MyState>.NoTransition())
+    .From(MyState.Idle).On("start").GoTo(MyState.Running)
+    .Build();
+
 var typedMealy = Mealy<MyState, string, int>.Builder(MyState.Idle)
     .From(MyState.Idle).On("start").GoTo(MyState.Running).Emits(1)
     .From(MyState.Running).On("stop").GoTo(MyState.Idle).Emits(0)
     .Build();
+
+int signal = typedMealy.ProcessInput("start");
+// signal == 1
 ```
+
+See `SemanticTests/StateMachines/MooreTests.cs` and `SemanticTests/StateMachines/MaleyTests.cs` for complete scenarios and edge cases.
 
 ---
 This project is in active development. More semantic utilities will be added to cover additional common scenarios.

--- a/README.md
+++ b/README.md
@@ -35,5 +35,37 @@ if (pattern.HasMatch())
 
 See the unit tests in `SemanticTests/Sequences/PatternMatchesTests.cs` for more usage details.
 
+## Example: Semantic State Machine Builders
+
+State machines can also be configured with a fluent API that guides transition definitions:
+
+```csharp
+var machine = Moore<MyState>.Builder(MyState.Idle)
+    .WithState(MyState.Idle, _ => StateMachine<MyState>.NoTransition())
+    .WithState(MyState.Running, _ => StateMachine<MyState>.NoTransition())
+    .WithState(MyState.Stopped, _ => StateMachine<MyState>.NoTransition())
+    .From(MyState.Idle).On("start").GoTo(MyState.Running)
+    .From(MyState.Running).On("stop").GoTo(MyState.Stopped)
+    .Build();
+```
+
+For Mealy machines, each transition concludes with an explicit output:
+
+```csharp
+var mealy = Mealy<MyState>.Builder(MyState.Idle)
+    .From(MyState.Idle).On("start").GoTo(MyState.Running).Emits("started")
+    .From(MyState.Running).On("stop").GoTo(MyState.Idle).Emits("stopped")
+    .Build();
+```
+
+Typed variants are available when you want compile-time safety on inputs and outputs:
+
+```csharp
+var typedMealy = Mealy<MyState, string, int>.Builder(MyState.Idle)
+    .From(MyState.Idle).On("start").GoTo(MyState.Running).Emits(1)
+    .From(MyState.Running).On("stop").GoTo(MyState.Idle).Emits(0)
+    .Build();
+```
+
 ---
 This project is in active development. More semantic utilities will be added to cover additional common scenarios.

--- a/Semantic/Semantic.csproj
+++ b/Semantic/Semantic.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Folder Include="Sequences/" />
+    <Folder Include="StateMachines/" />
     <Folder Include="Statistic/" />
   </ItemGroup>
 

--- a/Semantic/Sequences/PatternMatches.cs
+++ b/Semantic/Sequences/PatternMatches.cs
@@ -3,6 +3,7 @@ namespace Semantic.Sequences;
 internal class PatternMatches<T> : IPatternMatches<T>
 {
     private readonly T[] _pattern;
+    private readonly object _syncRoot = new();
     private int _currentIndex = 0;
 
     public event EventHandler? Matched;
@@ -17,27 +18,37 @@ internal class PatternMatches<T> : IPatternMatches<T>
 
     public bool HasMatch()
     {
-        return _currentIndex == _pattern.Length;
+        lock (_syncRoot)
+        {
+            return _currentIndex == _pattern.Length;
+        }
     }
 
     public void Next(T item)
     {
-        if (_currentIndex == _pattern.Length)
-        {
-            _currentIndex = 0;
-        }
+        EventHandler? matched = null;
 
-        if (EqualityComparer<T>.Default.Equals(_pattern[_currentIndex], item))
+        lock (_syncRoot)
         {
-            _currentIndex++;
             if (_currentIndex == _pattern.Length)
             {
-                Matched?.Invoke(this, EventArgs.Empty);
+                _currentIndex = 0;
+            }
+
+            if (EqualityComparer<T>.Default.Equals(_pattern[_currentIndex], item))
+            {
+                _currentIndex++;
+                if (_currentIndex == _pattern.Length)
+                {
+                    matched = Matched;
+                }
+            }
+            else
+            {
+                _currentIndex = 0; // Reset if the sequence breaks
             }
         }
-        else
-        {
-            _currentIndex = 0; // Reset if the sequence breaks
-        }
+
+        matched?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/Semantic/Sequences/PatternMatches.cs
+++ b/Semantic/Sequences/PatternMatches.cs
@@ -4,7 +4,9 @@ internal class PatternMatches<T> : IPatternMatches<T>
 {
     private readonly T[] _pattern;
     private readonly object _syncRoot = new();
+    private readonly int[] _longestPrefixSuffix;
     private int _currentIndex = 0;
+    private bool _hasMatch;
 
     public event EventHandler? Matched;
 
@@ -14,13 +16,14 @@ internal class PatternMatches<T> : IPatternMatches<T>
         _pattern = pattern.ToArray();
         if (_pattern.Length == 0)
             throw new ArgumentException("Pattern must not be empty.", nameof(pattern));
+        _longestPrefixSuffix = BuildLongestPrefixSuffix(_pattern);
     }
 
     public bool HasMatch()
     {
         lock (_syncRoot)
         {
-            return _currentIndex == _pattern.Length;
+            return _hasMatch;
         }
     }
 
@@ -30,25 +33,56 @@ internal class PatternMatches<T> : IPatternMatches<T>
 
         lock (_syncRoot)
         {
-            if (_currentIndex == _pattern.Length)
+            _hasMatch = false;
+
+            while (
+                _currentIndex > 0 &&
+                !EqualityComparer<T>.Default.Equals(_pattern[_currentIndex], item)
+            )
             {
-                _currentIndex = 0;
+                _currentIndex = _longestPrefixSuffix[_currentIndex - 1];
             }
 
             if (EqualityComparer<T>.Default.Equals(_pattern[_currentIndex], item))
             {
                 _currentIndex++;
-                if (_currentIndex == _pattern.Length)
-                {
-                    matched = Matched;
-                }
             }
-            else
+
+            if (_currentIndex == _pattern.Length)
             {
-                _currentIndex = 0; // Reset if the sequence breaks
+                _hasMatch = true;
+                matched = Matched;
+                _currentIndex = _longestPrefixSuffix[_currentIndex - 1];
             }
         }
 
         matched?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static int[] BuildLongestPrefixSuffix(T[] pattern)
+    {
+        var result = new int[pattern.Length];
+        var length = 0;
+
+        for (var i = 1; i < pattern.Length;)
+        {
+            if (EqualityComparer<T>.Default.Equals(pattern[i], pattern[length]))
+            {
+                length++;
+                result[i] = length;
+                i++;
+            }
+            else if (length > 0)
+            {
+                length = result[length - 1];
+            }
+            else
+            {
+                result[i] = 0;
+                i++;
+            }
+        }
+
+        return result;
     }
 }

--- a/Semantic/Sequences/SlidingWindow.cs
+++ b/Semantic/Sequences/SlidingWindow.cs
@@ -34,6 +34,7 @@ internal sealed class SlidingWindow<T> : ISlidingWindow<T>
 
     public void Clear()
     {
+        Array.Clear(_items);
         _index = -1;
         _isSliding = false;
     }

--- a/Semantic/StateMachines/Mealy.Generic.cs
+++ b/Semantic/StateMachines/Mealy.Generic.cs
@@ -1,0 +1,40 @@
+namespace Semantic.StateMachines;
+
+/// <summary>
+/// Represents a typed Mealy machine, a finite state machine where outputs depend on both state and input.
+/// </summary>
+/// <typeparam name="TState">Enumeration type representing states.</typeparam>
+/// <typeparam name="TInput">Input type used to trigger transitions.</typeparam>
+/// <typeparam name="TOutput">Output type emitted by transitions.</typeparam>
+public sealed class Mealy<TState, TInput, TOutput> : StateMachine<TState>
+    where TState : struct, Enum
+    where TInput : notnull
+{
+    private readonly Dictionary<(TState State, TInput Input), TransitionDefinition> _transitions;
+
+    public static MealyBuilder<TState, TInput, TOutput> Builder(TState initialState) => new(initialState);
+
+    internal Mealy(
+        TState initialState,
+        Dictionary<(TState State, TInput Input), TransitionDefinition> transitions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(transitions);
+        _transitions = new Dictionary<(TState State, TInput Input), TransitionDefinition>(transitions);
+        CurrentState = initialState;
+    }
+
+    public TOutput ProcessInput(TInput input)
+    {
+        return StateMachineRuntime.ProcessMealyInput(
+            CurrentState,
+            input,
+            _transitions,
+            transition => transition.ToState,
+            transition => transition.Output,
+            nextState => CurrentState = nextState
+        );
+    }
+
+    internal sealed record TransitionDefinition(TState ToState, TOutput Output);
+}

--- a/Semantic/StateMachines/Mealy.cs
+++ b/Semantic/StateMachines/Mealy.cs
@@ -6,5 +6,31 @@ namespace Semantic.StateMachines;
 /// <typeparam name="T">An enumeration type representing the states of the state machine.</typeparam>
 public class Mealy<T> : StateMachine<T> where T : struct, Enum
 {
+    private readonly Dictionary<(T State, object Input), TransitionDefinition> _transitions;
 
+    public static MealyBuilder<T> Builder(T initialState) => new(initialState);
+    public static MealyBuilder<T, TInput, TOutput> Builder<TInput, TOutput>(T initialState)
+        where TInput : notnull => new(initialState);
+
+    internal Mealy(T initialState, Dictionary<(T State, object Input), TransitionDefinition> transitions)
+    {
+        ArgumentNullException.ThrowIfNull(transitions);
+        _transitions = new Dictionary<(T State, object Input), TransitionDefinition>(transitions);
+        CurrentState = initialState;
+    }
+
+    public object? ProcessInput(object input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        return StateMachineRuntime.ProcessMealyInput(
+            CurrentState,
+            input,
+            _transitions,
+            transition => transition.ToState,
+            transition => transition.Output,
+            nextState => CurrentState = nextState
+        );
+    }
+
+    internal sealed record TransitionDefinition(T ToState, object? Output);
 }

--- a/Semantic/StateMachines/Mealy.cs
+++ b/Semantic/StateMachines/Mealy.cs
@@ -1,0 +1,10 @@
+namespace Semantic.StateMachines;
+
+/// <summary>
+/// Represents a Mealy machine, a finite state machine where outputs depend on both the current state and the inputs.
+/// </summary>
+/// <typeparam name="T">An enumeration type representing the states of the state machine.</typeparam>
+public class Mealy<T> : StateMachine<T> where T : struct, Enum
+{
+
+}

--- a/Semantic/StateMachines/MealyBuilder.Generic.cs
+++ b/Semantic/StateMachines/MealyBuilder.Generic.cs
@@ -1,0 +1,106 @@
+namespace Semantic.StateMachines;
+
+public sealed class MealyBuilder<TState, TInput, TOutput>
+    where TState : struct, Enum
+    where TInput : notnull
+{
+    private readonly TState _initialState;
+    private readonly Dictionary<(TState State, TInput Input), Mealy<TState, TInput, TOutput>.TransitionDefinition>
+        _transitions = new();
+
+    public MealyBuilder(TState initialState)
+    {
+        _initialState = initialState;
+    }
+
+    public FromStateBuilder From(TState fromState) => new(this, fromState);
+
+    public Mealy<TState, TInput, TOutput> Build() => Create();
+
+    public Mealy<TState, TInput, TOutput> Create()
+    {
+        return new Mealy<TState, TInput, TOutput>(_initialState, _transitions);
+    }
+
+    internal MealyBuilder<TState, TInput, TOutput> AddTransition(
+        TState fromState,
+        TInput input,
+        TState toState,
+        TOutput output
+    )
+    {
+        StateMachineRuntime.EnsureUniqueTransition(_transitions, fromState, input);
+
+        _transitions[(fromState, input)] = new Mealy<TState, TInput, TOutput>.TransitionDefinition(
+            toState,
+            output
+        );
+        return this;
+    }
+
+    public sealed class FromStateBuilder
+    {
+        private readonly MealyBuilder<TState, TInput, TOutput> _builder;
+        private readonly TState _fromState;
+
+        internal FromStateBuilder(MealyBuilder<TState, TInput, TOutput> builder, TState fromState)
+        {
+            _builder = builder;
+            _fromState = fromState;
+        }
+
+        public InputBuilder On(TInput input)
+        {
+            return new InputBuilder(_builder, _fromState, input);
+        }
+    }
+
+    public sealed class InputBuilder
+    {
+        private readonly MealyBuilder<TState, TInput, TOutput> _builder;
+        private readonly TState _fromState;
+        private readonly TInput _input;
+
+        internal InputBuilder(
+            MealyBuilder<TState, TInput, TOutput> builder,
+            TState fromState,
+            TInput input
+        )
+        {
+            _builder = builder;
+            _fromState = fromState;
+            _input = input;
+        }
+
+        public ToStateBuilder GoTo(TState toState)
+        {
+            return new ToStateBuilder(_builder, _fromState, _input, toState);
+        }
+    }
+
+    public sealed class ToStateBuilder
+    {
+        private readonly MealyBuilder<TState, TInput, TOutput> _builder;
+        private readonly TState _fromState;
+        private readonly TInput _input;
+        private readonly TState _toState;
+
+        internal ToStateBuilder(
+            MealyBuilder<TState, TInput, TOutput> builder,
+            TState fromState,
+            TInput input,
+            TState toState
+        )
+        {
+            _builder = builder;
+            _fromState = fromState;
+            _input = input;
+            _toState = toState;
+        }
+
+        public MealyBuilder<TState, TInput, TOutput> Emits(TOutput output)
+        {
+            return _builder.AddTransition(_fromState, _input, _toState, output);
+        }
+    }
+}

--- a/Semantic/StateMachines/MealyBuilder.cs
+++ b/Semantic/StateMachines/MealyBuilder.cs
@@ -1,0 +1,88 @@
+namespace Semantic.StateMachines;
+
+public sealed class MealyBuilder<T> where T : struct, Enum
+{
+    private readonly T _initialState;
+    private readonly Dictionary<(T State, object Input), Mealy<T>.TransitionDefinition> _transitions = new();
+
+    public MealyBuilder(T initialState)
+    {
+        _initialState = initialState;
+    }
+
+    public FromStateBuilder From(T fromState) => new(this, fromState);
+
+    public Mealy<T> Build() => Create();
+
+    public Mealy<T> Create()
+    {
+        return new Mealy<T>(_initialState, _transitions);
+    }
+
+    internal MealyBuilder<T> AddTransition(T fromState, object input, T toState, object? output)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        StateMachineRuntime.EnsureUniqueTransition(_transitions, fromState, input);
+
+        _transitions[(fromState, input)] = new Mealy<T>.TransitionDefinition(toState, output);
+        return this;
+    }
+
+    public sealed class FromStateBuilder
+    {
+        private readonly MealyBuilder<T> _builder;
+        private readonly T _fromState;
+
+        internal FromStateBuilder(MealyBuilder<T> builder, T fromState)
+        {
+            _builder = builder;
+            _fromState = fromState;
+        }
+
+        public InputBuilder On(object input)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            return new InputBuilder(_builder, _fromState, input);
+        }
+    }
+
+    public sealed class InputBuilder
+    {
+        private readonly MealyBuilder<T> _builder;
+        private readonly T _fromState;
+        private readonly object _input;
+
+        internal InputBuilder(MealyBuilder<T> builder, T fromState, object input)
+        {
+            _builder = builder;
+            _fromState = fromState;
+            _input = input;
+        }
+
+        public ToStateBuilder GoTo(T toState)
+        {
+            return new ToStateBuilder(_builder, _fromState, _input, toState);
+        }
+    }
+
+    public sealed class ToStateBuilder
+    {
+        private readonly MealyBuilder<T> _builder;
+        private readonly T _fromState;
+        private readonly object _input;
+        private readonly T _toState;
+
+        internal ToStateBuilder(MealyBuilder<T> builder, T fromState, object input, T toState)
+        {
+            _builder = builder;
+            _fromState = fromState;
+            _input = input;
+            _toState = toState;
+        }
+
+        public MealyBuilder<T> Emits(object? output)
+        {
+            return _builder.AddTransition(_fromState, _input, _toState, output);
+        }
+    }
+}

--- a/Semantic/StateMachines/Moore.Generic.cs
+++ b/Semantic/StateMachines/Moore.Generic.cs
@@ -1,0 +1,43 @@
+namespace Semantic.StateMachines;
+
+/// <summary>
+/// Represents a typed Moore machine, a finite state machine where behavior depends on the current state.
+/// </summary>
+/// <typeparam name="TState">Enumeration type representing states.</typeparam>
+/// <typeparam name="TInput">Input type used to trigger transitions.</typeparam>
+public sealed class Moore<TState, TInput> : StateMachine<TState>
+    where TState : struct, Enum
+    where TInput : notnull
+{
+    private readonly Dictionary<TState, Func<TInput, Transition<TState>>> _stateOutputs;
+    private readonly Dictionary<(TState State, TInput Input), TState> _transitions;
+
+    public static MooreBuilder<TState, TInput> Builder(TState initialState) => new(initialState);
+
+    internal Moore(
+        TState initialState,
+        Dictionary<TState, Func<TInput, Transition<TState>>> stateOutputs,
+        Dictionary<(TState State, TInput Input), TState> transitions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(stateOutputs);
+        ArgumentNullException.ThrowIfNull(transitions);
+
+        StateMachineRuntime.EnsureAllStatesHaveOutputs(stateOutputs);
+
+        _stateOutputs = new Dictionary<TState, Func<TInput, Transition<TState>>>(stateOutputs);
+        _transitions = new Dictionary<(TState State, TInput Input), TState>(transitions);
+        CurrentState = initialState;
+    }
+
+    public void ProcessInput(TInput input)
+    {
+        StateMachineRuntime.ProcessMooreInput(
+            CurrentState,
+            input,
+            _transitions,
+            _stateOutputs,
+            nextState => CurrentState = nextState
+        );
+    }
+}

--- a/Semantic/StateMachines/Moore.cs
+++ b/Semantic/StateMachines/Moore.cs
@@ -9,34 +9,37 @@ namespace Semantic.StateMachines;
 public class Moore<T> : StateMachine<T> where T : struct, Enum
 {
     private readonly Dictionary<T, Func<object, Transition<T>>> _stateOutputs;
+    private readonly Dictionary<(T State, object Input), T> _transitions;
 
     public static MooreBuilder<T> Builder(T initialState) => new MooreBuilder<T>(initialState);
+    public static MooreBuilder<T, TInput> Builder<TInput>(T initialState)
+        where TInput : notnull => new(initialState);
 
-    internal Moore(T initialState, 
-    Dictionary<T, Func<object, Transition<T>>> stateOutputs)
+    internal Moore(
+        T initialState,
+        Dictionary<T, Func<object, Transition<T>>> stateOutputs,
+        Dictionary<(T State, object Input), T> transitions
+    )
     {
-        foreach (var state in Enum.GetValues<T>())
-        {
-            if(stateOutputs.ContainsKey(state)) continue;
-                throw new ArgumentException($"State {state} is not defined in the state outputs.");
-        }
-        _stateOutputs = stateOutputs;
+        ArgumentNullException.ThrowIfNull(stateOutputs);
+        ArgumentNullException.ThrowIfNull(transitions);
+
+        StateMachineRuntime.EnsureAllStatesHaveOutputs(stateOutputs);
+        _stateOutputs = new Dictionary<T, Func<object, Transition<T>>>(stateOutputs);
+        _transitions = new Dictionary<(T State, object Input), T>(transitions);
         CurrentState = initialState;
     }
 
     public void ProcessInput(object input)
     {
-        if (_stateOutputs.TryGetValue(CurrentState, out var outputFunc))
-        {
-            var transition = outputFunc(input);
-            if(transition.State is not null && !EqualityComparer<T>.Default.Equals(transition.State.Value, CurrentState))
-            {
-                CurrentState = transition.State.Value;
-            }
-        }
-        else
-        {
-            throw new InvalidOperationException($"No transition defined from state {CurrentState} on input {input}");
-        }
+        ArgumentNullException.ThrowIfNull(input);
+
+        StateMachineRuntime.ProcessMooreInput(
+            CurrentState,
+            input,
+            _transitions,
+            _stateOutputs,
+            nextState => CurrentState = nextState
+        );
     }
 }

--- a/Semantic/StateMachines/Moore.cs
+++ b/Semantic/StateMachines/Moore.cs
@@ -8,10 +8,35 @@ namespace Semantic.StateMachines;
 /// <typeparam name="T">An enumeration type representing the states of the state machine.</typeparam>
 public class Moore<T> : StateMachine<T> where T : struct, Enum
 {
+    private readonly Dictionary<T, Func<object, Transition<T>>> _stateOutputs;
+
     public static MooreBuilder<T> Builder(T initialState) => new MooreBuilder<T>(initialState);
 
-    internal Moore(T initialState)
+    internal Moore(T initialState, 
+    Dictionary<T, Func<object, Transition<T>>> stateOutputs)
     {
+        foreach (var state in Enum.GetValues<T>())
+        {
+            if(stateOutputs.ContainsKey(state)) continue;
+                throw new ArgumentException($"State {state} is not defined in the state outputs.");
+        }
+        _stateOutputs = stateOutputs;
         CurrentState = initialState;
+    }
+
+    public void ProcessInput(object input)
+    {
+        if (_stateOutputs.TryGetValue(CurrentState, out var outputFunc))
+        {
+            var transition = outputFunc(input);
+            if(transition.State is not null && !EqualityComparer<T>.Default.Equals(transition.State.Value, CurrentState))
+            {
+                CurrentState = transition.State.Value;
+            }
+        }
+        else
+        {
+            throw new InvalidOperationException($"No transition defined from state {CurrentState} on input {input}");
+        }
     }
 }

--- a/Semantic/StateMachines/Moore.cs
+++ b/Semantic/StateMachines/Moore.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Semantic.StateMachines;
+
+/// <summary>
+/// Represents a Moore machine, a finite state machine where outputs depend only on the current state.
+/// </summary>
+/// <typeparam name="T">An enumeration type representing the states of the state machine.</typeparam>
+public class Moore<T> : StateMachine<T> where T : struct, Enum
+{
+
+}

--- a/Semantic/StateMachines/Moore.cs
+++ b/Semantic/StateMachines/Moore.cs
@@ -8,5 +8,10 @@ namespace Semantic.StateMachines;
 /// <typeparam name="T">An enumeration type representing the states of the state machine.</typeparam>
 public class Moore<T> : StateMachine<T> where T : struct, Enum
 {
+    public static MooreBuilder<T> Builder(T initialState) => new MooreBuilder<T>(initialState);
 
+    internal Moore(T initialState)
+    {
+        CurrentState = initialState;
+    }
 }

--- a/Semantic/StateMachines/MooreBuilder.Generic.cs
+++ b/Semantic/StateMachines/MooreBuilder.Generic.cs
@@ -1,0 +1,79 @@
+namespace Semantic.StateMachines;
+
+public sealed class MooreBuilder<TState, TInput>
+    where TState : struct, Enum
+    where TInput : notnull
+{
+    private readonly Dictionary<TState, Func<TInput, StateMachine<TState>.Transition<TState>>> _stateOutputs =
+        new();
+    private readonly Dictionary<(TState State, TInput Input), TState> _transitions = new();
+    private readonly TState _initialState;
+
+    public MooreBuilder(TState initialState)
+    {
+        _initialState = initialState;
+    }
+
+    public MooreBuilder<TState, TInput> WithState(
+        TState state,
+        Func<TInput, StateMachine<TState>.Transition<TState>> output
+    )
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        _stateOutputs[state] = output;
+        return this;
+    }
+
+    public MooreBuilder<TState, TInput> WithTransition(TState fromState, TInput input, TState toState)
+    {
+        StateMachineRuntime.EnsureUniqueTransition(_transitions, fromState, input);
+
+        _transitions[(fromState, input)] = toState;
+        return this;
+    }
+
+    public FromStateBuilder From(TState fromState) => new(this, fromState);
+
+    public Moore<TState, TInput> Build() => Create();
+
+    public Moore<TState, TInput> Create()
+    {
+        return new Moore<TState, TInput>(_initialState, _stateOutputs, _transitions);
+    }
+
+    public sealed class FromStateBuilder
+    {
+        private readonly MooreBuilder<TState, TInput> _builder;
+        private readonly TState _fromState;
+
+        internal FromStateBuilder(MooreBuilder<TState, TInput> builder, TState fromState)
+        {
+            _builder = builder;
+            _fromState = fromState;
+        }
+
+        public OnInputBuilder On(TInput input)
+        {
+            return new OnInputBuilder(_builder, _fromState, input);
+        }
+    }
+
+    public sealed class OnInputBuilder
+    {
+        private readonly MooreBuilder<TState, TInput> _builder;
+        private readonly TState _fromState;
+        private readonly TInput _input;
+
+        internal OnInputBuilder(MooreBuilder<TState, TInput> builder, TState fromState, TInput input)
+        {
+            _builder = builder;
+            _fromState = fromState;
+            _input = input;
+        }
+
+        public MooreBuilder<TState, TInput> GoTo(TState toState)
+        {
+            return _builder.WithTransition(_fromState, _input, toState);
+        }
+    }
+}

--- a/Semantic/StateMachines/MooreBuilder.cs
+++ b/Semantic/StateMachines/MooreBuilder.cs
@@ -1,0 +1,29 @@
+namespace Semantic.StateMachines;
+
+public class MooreBuilder<T> where T : struct, Enum
+{
+    private readonly Dictionary<T, Func<object, StateMachine<T>.Transition<T>>> _stateOutputs = new();
+    private readonly Dictionary<(T State, object Input), T> _transitions = new();
+    private readonly T initialState;
+
+    public MooreBuilder(T initialState)
+    {
+        this.initialState = initialState;
+    }
+    public MooreBuilder<T> WithState(T state, Func<object, StateMachine<T>.Transition<T>> output)
+    {
+        _stateOutputs[state] = output;
+        return this;
+    }
+
+    public MooreBuilder<T> WithTransition(T fromState, object input, T toState)
+    {
+        _transitions[(fromState, input)] = toState;
+        return this;
+    }
+
+    public Moore<T> Create()
+    {
+        return new Moore<T>(initialState);
+    }
+}

--- a/Semantic/StateMachines/MooreBuilder.cs
+++ b/Semantic/StateMachines/MooreBuilder.cs
@@ -4,26 +4,71 @@ public class MooreBuilder<T> where T : struct, Enum
 {
     private readonly Dictionary<T, Func<object, StateMachine<T>.Transition<T>>> _stateOutputs = new();
     private readonly Dictionary<(T State, object Input), T> _transitions = new();
-    private readonly T initialState;
+    private readonly T _initialState;
 
     public MooreBuilder(T initialState)
     {
-        this.initialState = initialState;
+        _initialState = initialState;
     }
+
     public MooreBuilder<T> WithState(T state, Func<object, StateMachine<T>.Transition<T>> output)
     {
+        ArgumentNullException.ThrowIfNull(output);
         _stateOutputs[state] = output;
         return this;
     }
 
     public MooreBuilder<T> WithTransition(T fromState, object input, T toState)
     {
+        ArgumentNullException.ThrowIfNull(input);
+        StateMachineRuntime.EnsureUniqueTransition(_transitions, fromState, input);
         _transitions[(fromState, input)] = toState;
         return this;
     }
 
+    public FromStateBuilder From(T fromState) => new(this, fromState);
+
+    public Moore<T> Build() => Create();
+
     public Moore<T> Create()
     {
-        return new Moore<T>(initialState, _stateOutputs);
+        return new Moore<T>(_initialState, _stateOutputs, _transitions);
+    }
+
+    public sealed class FromStateBuilder
+    {
+        private readonly MooreBuilder<T> _builder;
+        private readonly T _fromState;
+
+        internal FromStateBuilder(MooreBuilder<T> builder, T fromState)
+        {
+            _builder = builder;
+            _fromState = fromState;
+        }
+
+        public OnInputBuilder On(object input)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+            return new OnInputBuilder(_builder, _fromState, input);
+        }
+    }
+
+    public sealed class OnInputBuilder
+    {
+        private readonly MooreBuilder<T> _builder;
+        private readonly T _fromState;
+        private readonly object _input;
+
+        internal OnInputBuilder(MooreBuilder<T> builder, T fromState, object input)
+        {
+            _builder = builder;
+            _fromState = fromState;
+            _input = input;
+        }
+
+        public MooreBuilder<T> GoTo(T toState)
+        {
+            return _builder.WithTransition(_fromState, _input, toState);
+        }
     }
 }

--- a/Semantic/StateMachines/MooreBuilder.cs
+++ b/Semantic/StateMachines/MooreBuilder.cs
@@ -24,6 +24,6 @@ public class MooreBuilder<T> where T : struct, Enum
 
     public Moore<T> Create()
     {
-        return new Moore<T>(initialState);
+        return new Moore<T>(initialState, _stateOutputs);
     }
 }

--- a/Semantic/StateMachines/StateMachine.cs
+++ b/Semantic/StateMachines/StateMachine.cs
@@ -1,0 +1,21 @@
+namespace Semantic.StateMachines;
+
+/// <summary>
+/// Provides a base class for implementing finite state machines.
+/// </summary>
+/// <typeparam name="T">An enumeration type representing the states of the state machine.</typeparam>
+public abstract class StateMachine<T> where T : struct, Enum
+{
+    /// <summary>
+    /// Gets or sets the current state of the state machine.
+    /// </summary>
+    public T CurrentState { get; protected set; }
+
+    public record Transition<TState> where TState : struct, Enum
+    {
+        public required TState? State { get; init; }
+
+        public static Transition<TState> To(TState state) => new Transition<TState> { State = state };
+        public static Transition<TState> NoTransition() => new Transition<TState> { State = null };
+    }
+}

--- a/Semantic/StateMachines/StateMachine.cs
+++ b/Semantic/StateMachines/StateMachine.cs
@@ -6,10 +6,68 @@ namespace Semantic.StateMachines;
 /// <typeparam name="T">An enumeration type representing the states of the state machine.</typeparam>
 public abstract class StateMachine<T> where T : struct, Enum
 {
+    private readonly object _stateLock = new();
+    private T _currentState;
+
+    /// <summary>
+    /// Raised when the current state transitions to a different value.
+    /// </summary>
+    public event EventHandler<TransitionEventArgs>? OnTransition;
+
     /// <summary>
     /// Gets or sets the current state of the state machine.
     /// </summary>
-    public T CurrentState { get; protected set; }
+    /// <remarks>This property is thread-safe and can be safely accessed from multiple threads.</remarks>
+    public T CurrentState
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                return _currentState;
+            }
+        }
+        protected set
+        {
+            T fromStatus = default;
+            var hasChanged = false;
+            EventHandler<TransitionEventArgs>? handler = null;
+
+            lock (_stateLock)
+            {
+                if (EqualityComparer<T>.Default.Equals(_currentState, value))
+                {
+                    return;
+                }
+
+                fromStatus = _currentState;
+                _currentState = value;
+                hasChanged = true;
+                handler = OnTransition;
+            }
+
+            if (hasChanged)
+            {
+                handler?.Invoke(this, new TransitionEventArgs(fromStatus, value));
+            }
+        }
+    }
+
+    public sealed class TransitionEventArgs : EventArgs
+    {
+        public TransitionEventArgs(T fromStatus, T toStatus)
+        {
+            FromStatus = fromStatus;
+            ToStatus = toStatus;
+        }
+
+        public T FromStatus { get; }
+        public T ToStatus { get; }
+    }
+
+
+    public static Transition<T> GoToState(T state) => StateMachine<T>.Transition<T>.To(state);
+    public static Transition<T> NoTransition() => StateMachine<T>.Transition<T>.NoTransition();
 
     public record Transition<TState> where TState : struct, Enum
     {

--- a/Semantic/StateMachines/StateMachineRuntime.cs
+++ b/Semantic/StateMachines/StateMachineRuntime.cs
@@ -1,0 +1,101 @@
+namespace Semantic.StateMachines;
+
+internal static class StateMachineRuntime
+{
+    public static void EnsureAllStatesHaveOutputs<TState, TInput>(
+        IDictionary<TState, Func<TInput, StateMachine<TState>.Transition<TState>>> stateOutputs
+    )
+        where TState : struct, Enum
+    {
+        foreach (var state in Enum.GetValues<TState>())
+        {
+            if (!stateOutputs.ContainsKey(state))
+            {
+                throw new ArgumentException($"State {state} is not defined in the state outputs.");
+            }
+        }
+    }
+
+    public static void EnsureUniqueTransition<TState, TInput, TValue>(
+        IDictionary<(TState State, TInput Input), TValue> transitions,
+        TState fromState,
+        TInput input
+    )
+        where TState : struct, Enum
+        where TInput : notnull
+    {
+        if (transitions.ContainsKey((fromState, input)))
+        {
+            throw new InvalidOperationException(
+                $"Transition already defined for state {fromState} and input {input}."
+            );
+        }
+    }
+
+    public static void ProcessMooreInput<TState, TInput>(
+        TState currentState,
+        TInput input,
+        IDictionary<(TState State, TInput Input), TState> transitions,
+        IDictionary<TState, Func<TInput, StateMachine<TState>.Transition<TState>>> stateOutputs,
+        Action<TState> setCurrentState
+    )
+        where TState : struct, Enum
+        where TInput : notnull
+    {
+        if (transitions.TryGetValue((currentState, input), out var nextState))
+        {
+            if (!EqualityComparer<TState>.Default.Equals(nextState, currentState))
+            {
+                setCurrentState(nextState);
+            }
+            return;
+        }
+
+        if (!stateOutputs.TryGetValue(currentState, out var outputFunc))
+        {
+            throw new InvalidOperationException(
+                $"No transition defined from state {currentState} on input {input}."
+            );
+        }
+
+        var transition = outputFunc(input)
+            ?? throw new InvalidOperationException(
+                $"Output function for state {currentState} returned null transition."
+            );
+
+        if (
+            transition.State is not null &&
+            !EqualityComparer<TState>.Default.Equals(transition.State.Value, currentState)
+        )
+        {
+            setCurrentState(transition.State.Value);
+        }
+    }
+
+    public static TOutput ProcessMealyInput<TState, TInput, TTransition, TOutput>(
+        TState currentState,
+        TInput input,
+        IDictionary<(TState State, TInput Input), TTransition> transitions,
+        Func<TTransition, TState> getToState,
+        Func<TTransition, TOutput> getOutput,
+        Action<TState> setCurrentState
+    )
+        where TState : struct, Enum
+        where TInput : notnull
+    {
+        if (!transitions.TryGetValue((currentState, input), out var transition))
+        {
+            throw new InvalidOperationException(
+                $"No transition defined from state {currentState} on input {input}."
+            );
+        }
+
+        var nextState = getToState(transition);
+        if (!EqualityComparer<TState>.Default.Equals(nextState, currentState))
+        {
+            setCurrentState(nextState);
+        }
+
+        return getOutput(transition);
+    }
+}

--- a/SemanticBenchmarks/SemanticBenchmarks.csproj
+++ b/SemanticBenchmarks/SemanticBenchmarks.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SemanticTests/SemanticTests.csproj
+++ b/SemanticTests/SemanticTests.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="StateMachines/" />
     <Folder Include="Statistic/" />
   </ItemGroup>
 

--- a/SemanticTests/SemanticTests.csproj
+++ b/SemanticTests/SemanticTests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <RunSettingsFilePath>../coverlet.runsettings</RunSettingsFilePath>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)..\coverlet.runsettings</RunSettingsFilePath>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/SemanticTests/SemanticTests.csproj
+++ b/SemanticTests/SemanticTests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SemanticTests/Sequences/PatternMatchesTests.cs
+++ b/SemanticTests/Sequences/PatternMatchesTests.cs
@@ -128,5 +128,36 @@ namespace SemanticTests.Sequences
             pattern.Next(3);
             Assert.True(pattern.HasMatch());
         }
+
+        [Fact]
+        public void TestPatternMatches_HandlesOverlapAfterMismatch()
+        {
+            var pattern = PatternMatchesBuilder.Create(1, 2, 3);
+
+            pattern.Next(1);
+            pattern.Next(2);
+            pattern.Next(1);
+            Assert.False(pattern.HasMatch());
+
+            pattern.Next(2);
+            Assert.False(pattern.HasMatch());
+
+            pattern.Next(3);
+            Assert.True(pattern.HasMatch());
+        }
+
+        [Fact]
+        public void TestPatternMatches_HandlesRepeatedPrefixPattern()
+        {
+            var pattern = PatternMatchesBuilder.Create(1, 1, 2);
+
+            pattern.Next(1);
+            pattern.Next(1);
+            pattern.Next(1);
+            Assert.False(pattern.HasMatch());
+
+            pattern.Next(2);
+            Assert.True(pattern.HasMatch());
+        }
     }
 }

--- a/SemanticTests/Sequences/PatternMatchesTests.cs
+++ b/SemanticTests/Sequences/PatternMatchesTests.cs
@@ -86,6 +86,26 @@ namespace SemanticTests.Sequences
         }
 
         [Fact]
+        public async Task TestPatternMatches_ConcurrentAccess_DoesNotThrow()
+        {
+            var pattern = PatternMatchesBuilder.StartsWith(1)
+                .ContinuesWith(2)
+                .EndsWith(3);
+
+            var tasks = Enumerable.Range(0, Environment.ProcessorCount)
+                .Select(worker => Task.Run(() =>
+                {
+                    for (int i = 0; i < 10_000; i++)
+                    {
+                        pattern.Next((i % 3) + 1);
+                        _ = pattern.HasMatch();
+                    }
+                }));
+
+            await Task.WhenAll(tasks);
+        }
+
+        [Fact]
         public void TestCreate_ThrowsOnNullPattern()
         {
             Assert.Throws<ArgumentNullException>(() => PatternMatchesBuilder.Create<int>(null!));

--- a/SemanticTests/StateMachines/MaleyTests.cs
+++ b/SemanticTests/StateMachines/MaleyTests.cs
@@ -13,14 +13,161 @@ public class MaleyTests
     }
 
     [Fact]
+    public void MealyStateMachine_ShouldThrowOnNullInput()
+    {
+        var machine = Mealy<TestStates>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits("A->B")
+            .Build();
+
+        Assert.Throws<ArgumentNullException>(() => machine.ProcessInput(null!));
+    }
+
+    [Fact]
+    public void MealyBuilder_ShouldRejectInvalidConfiguration()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            Mealy<TestStates>.Builder(TestStates.StateA).From(TestStates.StateA).On(null!)
+        );
+    }
+
+    [Fact]
+    public void MealyBuilder_ShouldRejectDuplicateTransition()
+    {
+        var builder = Mealy<TestStates>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits("A->B");
+
+        Assert.Throws<InvalidOperationException>(() =>
+            builder.From(TestStates.StateA).On("toB").GoTo(TestStates.StateC).Emits("A->C")
+        );
+    }
+
+    [Fact]
+    public void MealyStateMachine_ShouldAllowNullOutput()
+    {
+        var machine = Mealy<TestStates>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("stay").GoTo(TestStates.StateA).Emits(null)
+            .Build();
+
+        var output = machine.ProcessInput("stay");
+
+        Assert.Null(output);
+        Assert.Equal(TestStates.StateA, machine.CurrentState);
+    }
+
+    [Fact]
+    public void TypedMealyBuilder_ShouldRejectDuplicateTransition()
+    {
+        var builder = Mealy<TestStates, string, int>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits(1);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            builder.From(TestStates.StateA).On("toB").GoTo(TestStates.StateC).Emits(2)
+        );
+    }
+
+    [Fact]
+    public void TypedMealyStateMachine_ShouldThrowWhenTransitionIsMissing()
+    {
+        var machine = Mealy<TestStates, string, int>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits(1)
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => machine.ProcessInput("missing"));
+    }
+
+    [Fact]
     public void MealyStateMachine_ShouldHaveCurrentState()
     {
         // Arrange
-        var mealyMachine = new Mealy<TestStates>();
+        var mealyMachine = Mealy<TestStates>.Builder(TestStates.StateB)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits("A->B")
+            .Build();
         // Act
         var currentState = mealyMachine.CurrentState;
         // Assert
-        Assert.Equal(default(TestStates), currentState);
+        Assert.Equal(TestStates.StateB, currentState);
     }
 
+    [Fact]
+    public void MealyStateMachine_ShouldTransitionAndEmitOutput()
+    {
+        var mealyMachine = Mealy<TestStates>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits("A->B")
+            .From(TestStates.StateB).On("toC").GoTo(TestStates.StateC).Emits("B->C")
+            .Build();
+
+        var output = mealyMachine.ProcessInput("toB");
+
+        Assert.Equal("A->B", output);
+        Assert.Equal(TestStates.StateB, mealyMachine.CurrentState);
+    }
+
+    [Fact]
+    public void MealyStateMachine_ShouldHandleMultipleSequentialTransitions()
+    {
+        var mealyMachine = Mealy<TestStates>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits("A->B")
+            .From(TestStates.StateB).On("toC").GoTo(TestStates.StateC).Emits("B->C")
+            .From(TestStates.StateC).On("toA").GoTo(TestStates.StateA).Emits("C->A")
+            .Build();
+
+        var output1 = mealyMachine.ProcessInput("toB");
+        var output2 = mealyMachine.ProcessInput("toC");
+        var output3 = mealyMachine.ProcessInput("toA");
+
+        Assert.Equal("A->B", output1);
+        Assert.Equal("B->C", output2);
+        Assert.Equal("C->A", output3);
+        Assert.Equal(TestStates.StateA, mealyMachine.CurrentState);
+    }
+
+    [Fact]
+    public void MealyStateMachine_ShouldThrowWhenTransitionIsMissing()
+    {
+        var mealyMachine = Mealy<TestStates>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits("A->B")
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => mealyMachine.ProcessInput("missing"));
+    }
+
+    [Fact]
+    public void TypedMealyStateMachine_ShouldTransitionAndEmitTypedOutput()
+    {
+        var mealyMachine = Mealy<TestStates, string, int>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits(10)
+            .From(TestStates.StateB).On("toC").GoTo(TestStates.StateC).Emits(20)
+            .Build();
+
+        var output = mealyMachine.ProcessInput("toB");
+
+        Assert.Equal(10, output);
+        Assert.Equal(TestStates.StateB, mealyMachine.CurrentState);
+    }
+
+    [Fact]
+    public void TypedMealyStateMachine_ShouldHandleSelfTransitionAndEmitOutput()
+    {
+        var mealyMachine = Mealy<TestStates, string, int>.Builder(TestStates.StateA)
+            .From(TestStates.StateA).On("stay").GoTo(TestStates.StateA).Emits(7)
+            .Build();
+
+        var output = mealyMachine.ProcessInput("stay");
+
+        Assert.Equal(7, output);
+        Assert.Equal(TestStates.StateA, mealyMachine.CurrentState);
+    }
+
+    [Fact]
+    public void TypedMealyBuilderFromLegacyEntryPoint_ShouldWork()
+    {
+        var mealyMachine = Mealy<TestStates>.Builder<string, int>(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB).Emits(99)
+            .Build();
+
+        var output = mealyMachine.ProcessInput("toB");
+
+        Assert.Equal(99, output);
+        Assert.Equal(TestStates.StateB, mealyMachine.CurrentState);
+    }
 }

--- a/SemanticTests/StateMachines/MaleyTests.cs
+++ b/SemanticTests/StateMachines/MaleyTests.cs
@@ -1,0 +1,26 @@
+using System;
+using Semantic.StateMachines;
+
+namespace SemanticTests.StateMachines;
+
+public class MaleyTests
+{
+    enum TestStates
+    {
+        StateA,
+        StateB,
+        StateC
+    }
+
+    [Fact]
+    public void MealyStateMachine_ShouldHaveCurrentState()
+    {
+        // Arrange
+        var mealyMachine = new Mealy<TestStates>();
+        // Act
+        var currentState = mealyMachine.CurrentState;
+        // Assert
+        Assert.Equal(default(TestStates), currentState);
+    }
+
+}

--- a/SemanticTests/StateMachines/MooreTests.cs
+++ b/SemanticTests/StateMachines/MooreTests.cs
@@ -17,8 +17,13 @@ public class MooreTests
     public void MooreStateMachine_ShouldHaveCurrentState()
     {
         // Arrange
-        var mooreMachine = Moore<TestStates>.Builder(TestStates.StateA)
-            .Create();
+        var mooreMachineBuilder = Moore<TestStates>.Builder(TestStates.StateA);
+
+        mooreMachineBuilder.WithState(TestStates.StateA, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition());
+        mooreMachineBuilder.WithState(TestStates.StateB, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition());
+        mooreMachineBuilder.WithState(TestStates.StateC, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition());
+
+        var mooreMachine = mooreMachineBuilder.Create();
 
         // Act
         var currentState = mooreMachine.CurrentState;
@@ -34,6 +39,7 @@ public class MooreTests
         var builder = Moore<TestStates>.Builder(TestStates.StateA)
             .WithState(TestStates.StateA, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
             .WithState(TestStates.StateB, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
             .WithTransition(TestStates.StateA, "toB", TestStates.StateB)
             .WithTransition(TestStates.StateB, "toA", TestStates.StateA);
 

--- a/SemanticTests/StateMachines/MooreTests.cs
+++ b/SemanticTests/StateMachines/MooreTests.cs
@@ -1,0 +1,29 @@
+using System;
+using Semantic.StateMachines;
+
+namespace SemanticTests.StateMachines;
+
+public class MooreTests
+{
+    enum TestStates
+    {
+        StateA,
+        StateB,
+        StateC
+    }
+
+
+    [Fact]
+    public void MooreStateMachine_ShouldHaveCurrentState()
+    {
+        // Arrange
+        var mooreMachine = new Moore<TestStates>();
+
+        // Act
+        var currentState = mooreMachine.CurrentState;
+
+        // Assert
+        Assert.Equal(default(TestStates), currentState);
+    }
+
+}

--- a/SemanticTests/StateMachines/MooreTests.cs
+++ b/SemanticTests/StateMachines/MooreTests.cs
@@ -12,12 +12,200 @@ public class MooreTests
         StateC
     }
 
+    [Fact]
+    public void StateMachineTransitionEvent_ShouldBeRaisedOnlyWhenStateChanges()
+    {
+        var machine = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .From(TestStates.StateA).On("toA").GoTo(TestStates.StateA)
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB)
+            .Build();
+
+        int eventCount = 0;
+        TestStates from = default;
+        TestStates to = default;
+        machine.OnTransition += (_, args) =>
+        {
+            eventCount++;
+            from = args.FromStatus;
+            to = args.ToStatus;
+        };
+
+        machine.ProcessInput("toA");
+        machine.ProcessInput("toB");
+
+        Assert.Equal(1, eventCount);
+        Assert.Equal(TestStates.StateA, from);
+        Assert.Equal(TestStates.StateB, to);
+    }
+
+    [Fact]
+    public void MooreStateMachine_ShouldUseStateOutputWhenNoExplicitTransitionMatches()
+    {
+        var machine = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, input =>
+                Equals(input, "toC")
+                    ? StateMachine<TestStates>.GoToState(TestStates.StateC)
+                    : StateMachine<TestStates>.NoTransition()
+            )
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .Build();
+
+        machine.ProcessInput("toC");
+
+        Assert.Equal(TestStates.StateC, machine.CurrentState);
+    }
+
+    [Fact]
+    public void MooreStateMachine_ShouldPreferExplicitTransitionOverStateOutputFallback()
+    {
+        var machine = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, input =>
+                Equals(input, "go")
+                    ? StateMachine<TestStates>.GoToState(TestStates.StateC)
+                    : StateMachine<TestStates>.NoTransition()
+            )
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .From(TestStates.StateA).On("go").GoTo(TestStates.StateB)
+            .Build();
+
+        machine.ProcessInput("go");
+
+        Assert.Equal(TestStates.StateB, machine.CurrentState);
+    }
+
+    [Fact]
+    public void MooreStateMachine_ShouldHandleMultipleSequentialTransitions()
+    {
+        var machine = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB)
+            .From(TestStates.StateB).On("toC").GoTo(TestStates.StateC)
+            .From(TestStates.StateC).On("toA").GoTo(TestStates.StateA)
+            .Build();
+
+        machine.ProcessInput("toB");
+        machine.ProcessInput("toC");
+        machine.ProcessInput("toA");
+
+        Assert.Equal(TestStates.StateA, machine.CurrentState);
+    }
+
+    [Fact]
+    public void MooreStateMachine_ShouldThrowWhenStateOutputReturnsNullTransition()
+    {
+        var machine = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => null!)
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => machine.ProcessInput("any"));
+    }
+
+    [Fact]
+    public void MooreStateMachine_ShouldThrowOnNullInput()
+    {
+        var machine = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .Build();
+
+        Assert.Throws<ArgumentNullException>(() => machine.ProcessInput(null!));
+    }
+
+    [Fact]
+    public void MooreBuilder_ShouldRejectInvalidConfiguration()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            Moore<TestStates>.Builder(TestStates.StateA)
+                .WithState(TestStates.StateA, null!)
+        );
+
+        Assert.Throws<ArgumentNullException>(() =>
+            Moore<TestStates>.Builder(TestStates.StateA)
+                .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+                .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+                .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+                .WithTransition(TestStates.StateA, null!, TestStates.StateB)
+        );
+    }
+
+    [Fact]
+    public void MooreBuilder_ShouldRejectDuplicateTransition()
+    {
+        var builder = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .WithTransition(TestStates.StateA, "toB", TestStates.StateB);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            builder.WithTransition(TestStates.StateA, "toB", TestStates.StateC)
+        );
+    }
+
+    [Fact]
+    public void MooreBuilder_ShouldRequireAllStatesInConfiguration()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Moore<TestStates>.Builder(TestStates.StateA)
+                .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+                .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+                .Build()
+        );
+    }
+
+    [Fact]
+    public void TypedMooreBuilder_ShouldRejectDuplicateTransition()
+    {
+        var builder = Moore<TestStates, string>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .WithTransition(TestStates.StateA, "toB", TestStates.StateB);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            builder.WithTransition(TestStates.StateA, "toB", TestStates.StateC)
+        );
+    }
+
+    [Fact]
+    public void TypedMooreStateMachine_ShouldThrowWhenStateOutputReturnsNullTransition()
+    {
+        var machine = Moore<TestStates, string>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => null!)
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .Build();
+
+        Assert.Throws<InvalidOperationException>(() => machine.ProcessInput("any"));
+    }
+
+    [Fact]
+    public void TypedMooreBuilder_ShouldRequireAllStatesInConfiguration()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Moore<TestStates, string>.Builder(TestStates.StateA)
+                .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+                .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+                .Build()
+        );
+    }
+
 
     [Fact]
     public void MooreStateMachine_ShouldHaveCurrentState()
     {
         // Arrange
-        var mooreMachineBuilder = Moore<TestStates>.Builder(TestStates.StateA);
+        var mooreMachineBuilder = Moore<TestStates>.Builder(TestStates.StateB);
 
         mooreMachineBuilder.WithState(TestStates.StateA, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition());
         mooreMachineBuilder.WithState(TestStates.StateB, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition());
@@ -29,7 +217,7 @@ public class MooreTests
         var currentState = mooreMachine.CurrentState;
 
         // Assert
-        Assert.Equal(default(TestStates), currentState);
+        Assert.Equal(TestStates.StateB, currentState);
     }
 
     [Fact]
@@ -40,16 +228,81 @@ public class MooreTests
             .WithState(TestStates.StateA, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
             .WithState(TestStates.StateB, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
             .WithState(TestStates.StateC, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
-            .WithTransition(TestStates.StateA, "toB", TestStates.StateB)
-            .WithTransition(TestStates.StateB, "toA", TestStates.StateA);
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB)
+            .From(TestStates.StateB).On("toA").GoTo(TestStates.StateA);
 
         var mooreMachine = builder.Create();
 
         // Act
+        mooreMachine.ProcessInput("toB");
         var currentState = mooreMachine.CurrentState;
 
         // Assert
-        Assert.Equal(TestStates.StateA, currentState);
+        Assert.Equal(TestStates.StateB, currentState);
     }
 
+    [Fact]
+    public void MooreStateMachine_ShouldKeepStateWhenNoTransitionIsDefined()
+    {
+        // Arrange
+        var machine = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
+            .Build();
+
+        // Act
+        machine.ProcessInput("missing");
+
+        // Assert
+        Assert.Equal(TestStates.StateA, machine.CurrentState);
+    }
+
+    [Fact]
+    public void TypedMooreStateMachine_ShouldApplyTypedTransition()
+    {
+        var machine = Moore<TestStates, string>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB)
+            .Build();
+
+        machine.ProcessInput("toB");
+
+        Assert.Equal(TestStates.StateB, machine.CurrentState);
+    }
+
+    [Fact]
+    public void TypedMooreStateMachine_ShouldUseStateOutputWhenNoExplicitTransitionMatches()
+    {
+        var machine = Moore<TestStates, string>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, input =>
+                input == "toC"
+                    ? StateMachine<TestStates>.GoToState(TestStates.StateC)
+                    : StateMachine<TestStates>.NoTransition()
+            )
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .Build();
+
+        machine.ProcessInput("toC");
+
+        Assert.Equal(TestStates.StateC, machine.CurrentState);
+    }
+
+    [Fact]
+    public void TypedMooreBuilderFromLegacyEntryPoint_ShouldWork()
+    {
+        var machine = Moore<TestStates>.Builder<string>(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.NoTransition())
+            .WithState(TestStates.StateC, _ => StateMachine<TestStates>.NoTransition())
+            .From(TestStates.StateA).On("toB").GoTo(TestStates.StateB)
+            .Build();
+
+        machine.ProcessInput("toB");
+
+        Assert.Equal(TestStates.StateB, machine.CurrentState);
+    }
 }

--- a/SemanticTests/StateMachines/MooreTests.cs
+++ b/SemanticTests/StateMachines/MooreTests.cs
@@ -17,13 +17,33 @@ public class MooreTests
     public void MooreStateMachine_ShouldHaveCurrentState()
     {
         // Arrange
-        var mooreMachine = new Moore<TestStates>();
+        var mooreMachine = Moore<TestStates>.Builder(TestStates.StateA)
+            .Create();
 
         // Act
         var currentState = mooreMachine.CurrentState;
 
         // Assert
         Assert.Equal(default(TestStates), currentState);
+    }
+
+    [Fact]
+    public void MooreStateMachine_ShouldAllowStateTransitions()
+    {
+        // Arrange
+        var builder = Moore<TestStates>.Builder(TestStates.StateA)
+            .WithState(TestStates.StateA, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
+            .WithState(TestStates.StateB, _ => StateMachine<TestStates>.Transition<TestStates>.NoTransition())
+            .WithTransition(TestStates.StateA, "toB", TestStates.StateB)
+            .WithTransition(TestStates.StateB, "toA", TestStates.StateA);
+
+        var mooreMachine = builder.Create();
+
+        // Act
+        var currentState = mooreMachine.CurrentState;
+
+        // Assert
+        Assert.Equal(TestStates.StateA, currentState);
     }
 
 }

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -2,11 +2,9 @@
 <RunSettings>
   <DataCollectionRunSettings>
     <DataCollectors>
-      <DataCollector friendlyName="XPlat code coverage">
+      <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
-          <Exclude>
-            <ModulePath>.*SemanticTests.csproj</ModulePath>
-          </Exclude>
+          <Format>cobertura</Format>
         </Configuration>
       </DataCollector>
     </DataCollectors>


### PR DESCRIPTION
## Summary
- implement robust semantic builders for Moore and Mealy state machines
- add typed variants for compile-time-safe inputs/outputs
- harden runtime behavior and remove internal duplication via shared runtime helpers
- expand test coverage with robustness and edge-case scenarios
- update outdated test/benchmark NuGet dependencies
- enrich README with concise usage examples for Sequences and StateMachines

## Key changes
- Moore/Mealy fluent DSL:
  - `From(...).On(...).GoTo(...)`
  - Mealy transitions end with `.Emits(...)`
- typed APIs:
  - `Moore<TState, TInput>`
  - `Mealy<TState, TInput, TOutput>`
- shared runtime internals:
  - centralized transition processing and duplicate-transition validation

## Validation
- `dotnet test SemanticTests/SemanticTests.csproj` passed (57/57)
- `dotnet build SemanticBenchmarks/SemanticBenchmarks.csproj` passed

Closes #23
Closes #24
Closes #25